### PR TITLE
load splinetables from disk instead of running splinefits on the fly

### DIFF
--- a/skyllh/core/backgroundpdf.py
+++ b/skyllh/core/backgroundpdf.py
@@ -16,7 +16,7 @@ class BackgroundMultiDimGridPDF(MultiDimGridPDF, IsBackgroundPDF):
     interpolated using a :class:`scipy.interpolate.RegularGridInterpolator`
     instance.
     """
-    def __init__(self, axis_binnings, pdf_grid_data, norm_factor_func=None):
+    def __init__(self, axis_binnings, pdf_path_to_splinetable=None, pdf_grid_data=None, norm_factor_func=None): 
         """Creates a new background PDF instance for a multi-dimensional PDF
         given as PDF values on a grid. The grid data is interpolated with a
         :class:`scipy.interpolate.RegularGridInterpolator` instance. As grid
@@ -28,6 +28,9 @@ class BackgroundMultiDimGridPDF(MultiDimGridPDF, IsBackgroundPDF):
             The sequence of BinningDefinition instances defining the binning of
             the PDF axes. The name of each BinningDefinition instance defines
             the event field name that should be used for querying the PDF.
+        pdf_path_to_splinetable : str
+            The path to the file that contains the spline table
+            (a pre-computed fit to pdf_grid_data)
         pdf_grid_data : n-dimensional numpy ndarray
             The n-dimensional numpy ndarray holding the PDF values at given grid
             points. The grid points must match the bin edges of the given
@@ -42,4 +45,4 @@ class BackgroundMultiDimGridPDF(MultiDimGridPDF, IsBackgroundPDF):
             with the current fit parameter names and values.
         """
         super(BackgroundMultiDimGridPDF, self).__init__(
-            axis_binnings, pdf_grid_data, norm_factor_func)
+            axis_binnings, pdf_path_to_splinetable, pdf_grid_data, norm_factor_func)

--- a/skyllh/core/dataset.py
+++ b/skyllh/core/dataset.py
@@ -1042,6 +1042,35 @@ class Dataset(object):
 
         self._aux_data_definitions[name] = pathfilenames
 
+    def get_aux_data_definition(self, name):
+        """Returns the data files from the auxiliary data definition from the
+        dataset.
+
+        Parameters
+        ----------
+        name : str
+            The name of the auxiliary data. The name is used as identifier for
+            the data within SkyLLH.
+       
+        Raises
+        ------
+        KeyError
+            If auxiliary data is already stored under the given name.
+
+
+        Returns
+        -------
+        _aux_data[name] : list of strings
+            The locations of the files defined in the auxiliary data
+        """
+        
+        if(not name in self._aux_data_definitions):
+            raise KeyError('The auxiliary data definition "%s" does not '
+                'exist in dataset "%s"!'%(name, self.name))
+
+        return self._aux_data_definitions[name]
+
+
     def add_aux_data(self, name, data):
         """Adds the given data as auxiliary data to this data set.
 

--- a/skyllh/core/signalpdf.py
+++ b/skyllh/core/signalpdf.py
@@ -292,7 +292,7 @@ class SignalMultiDimGridPDF(MultiDimGridPDF, IsSignalPDF):
     from pre-calculated PDF data on a grid. The grid data is interpolated using
     a :class:`scipy.interpolate.RegularGridInterpolator` instance.
     """
-    def __init__(self, axis_binnings, pdf_grid_data, norm_factor_func=None):
+    def __init__(self, axis_binnings, pdf_path_to_splinetable=None, pdf_grid_data=None, norm_factor_func=None):
         """Creates a new signal PDF instance for a multi-dimensional PDF given
         as PDF values on a grid. The grid data is interpolated with a
         :class:`scipy.interpolate.RegularGridInterpolator` instance. As grid
@@ -304,6 +304,9 @@ class SignalMultiDimGridPDF(MultiDimGridPDF, IsSignalPDF):
             The sequence of BinningDefinition instances defining the binning of
             the PDF axes. The name of each BinningDefinition instance defines
             the event field name that should be used for querying the PDF.
+        pdf_path_to_splinetable : str
+            The path to the file that contains the spline table
+            (a pre-computed fit to pdf_grid_data)
         pdf_grid_data : n-dimensional numpy ndarray
             The n-dimensional numpy ndarray holding the PDF values at given grid
             points. The grid points must match the bin edges of the given
@@ -319,6 +322,7 @@ class SignalMultiDimGridPDF(MultiDimGridPDF, IsSignalPDF):
         """
         super(SignalMultiDimGridPDF, self).__init__(
             axis_binnings=axis_binnings,
+            pdf_path_to_splinetable=pdf_path_to_splinetable,
             pdf_grid_data=pdf_grid_data,
             norm_factor_func=norm_factor_func)
 

--- a/skyllh/core/utils/multidimgridpdf.py
+++ b/skyllh/core/utils/multidimgridpdf.py
@@ -5,6 +5,7 @@ MultiDimGridPDF instances.
 """
 
 import numpy as np
+import os
 
 from skyllh.core.binning import BinningDefinition
 from skyllh.core.pdf import MultiDimGridPDF
@@ -29,6 +30,81 @@ def kde_pdf_bkg_norm_factor_func(pdf, tdm, fitparams):
     ``create_MultiDimGridPDF_from_kde_pdf`` function.
     """
     return 1. / (2 * np.pi)
+
+def create_MultiDimGridPDF_from_photosplinetable(
+        ds, data, info_key, splinetable_key, norm_factor_func=None,
+        kind=None, tl=None):
+    """Creates a MultiDimGridPDF instance with pdf values taken from KDE PDF
+    values stored in the dataset's auxiliary data.
+
+    Parameters
+    ----------
+    ds : Dataset instance
+        The Dataset instance the PDF applies to.
+    data : DatasetData instance
+        The DatasetData instance that holds the auxiliary data of the data set.
+    info_key : str
+        The auxiliary data name for the PDF information (e.g. axis definitions)
+    splinetable_key : str 
+        The auxiliary data name for the name of the splinetablefile 
+    norm_factor_func : callable | None
+        The normalization factor function. It must have the following call
+        signature:
+            __call__(pdf, tdm, fitparams)
+    kind : str | None
+        The kind of PDF to create. This is either ``'sig'`` for a
+        SignalMultiDimGridPDF or ``'bkg'`` for a BackgroundMultiDimGridPDF
+        instance. If set to None, a MultiDimGridPDF instance is created.
+    tl : TimeLord instance | None
+        The optional TimeLord instance to use for measuring timing information.
+
+    Returns
+    -------
+    pdf : SignalMultiDimGridPDF instance | BackgroundMultiDimGridPDF instance |
+          MultiDimGridPDF instance
+        The created PDF instance. Depending on the ``kind`` argument, this is
+        a SignalMultiDimGridPDF, a BackgroundMultiDimGridPDF, or a
+        MultiDimGridPDF instance.
+    """
+
+
+    if(kind is None):
+        pdf_type = MultiDimGridPDF
+    elif(kind == 'sig'):
+        pdf_type = SignalMultiDimGridPDF
+    elif(kind == 'bkg'):
+        pdf_type = BackgroundMultiDimGridPDF
+    else:
+        raise ValueError('The kind argument must be None, "sig", or "bkg"! '
+            'Currently it is '+str(kind)+'!')
+
+    # Load the PDF data from the auxilary files.
+    num_dict = ds.load_aux_data(info_key, tl=tl)  
+
+    kde_pdf_axis_name_map = ds.load_aux_data('KDE_PDF_axis_name_map', tl=tl)
+    kde_pdf_axis_name_map_inv = dict(
+        [(v,k) for (k,v) in kde_pdf_axis_name_map.items()])
+
+    axis_binnings = [
+        BinningDefinition(
+            kde_pdf_axis_name_map_inv[var], num_dict['bins'][idx])
+        for (idx,var) in enumerate(num_dict['vars'])
+    ]
+ 
+    # get splinetable file
+    splinetable_files = ds.get_aux_data_definition(splinetable_key)
+    assert(len(splinetable_files)==1)
+    splinetable_file = os.path.join(ds.root_dir, splinetable_files[0])
+
+    pdf = pdf_type(
+        axis_binnings,
+        pdf_path_to_splinetable=splinetable_file,
+        pdf_grid_data=None,
+        norm_factor_func=norm_factor_func)
+
+    return pdf
+
+
 
 def create_MultiDimGridPDF_from_kde_pdf(
         ds, data, numerator_key, denumerator_key=None, norm_factor_func=None,
@@ -124,7 +200,8 @@ def create_MultiDimGridPDF_from_kde_pdf(
 
     pdf = pdf_type(
         axis_binnings,
-        vals,
-        norm_factor_func)
+        pdf_path_to_splinetable=None,
+        pdf_grid_data=vals,
+        norm_factor_func=norm_factor_func)
 
     return pdf

--- a/skyllh/core/utils/multidimgridpdf.py
+++ b/skyllh/core/utils/multidimgridpdf.py
@@ -92,9 +92,9 @@ def create_MultiDimGridPDF_from_photosplinetable(
     ]
  
     # get splinetable file
-    splinetable_files = ds.get_aux_data_definition(splinetable_key)
-    assert(len(splinetable_files)==1)
-    splinetable_file = os.path.join(ds.root_dir, splinetable_files[0])
+    splinetable_file_list = ds.get_aux_data_definition(splinetable_key) 
+    # this is a list with only one element
+    splinetable_file = os.path.join(ds.root_dir, splinetable_file_list[0])
 
     pdf = pdf_type(
         axis_binnings,


### PR DESCRIPTION
Instead of fitting splines on the fly, skyllh now loads pre-computed splines from splinetables on disk.
This significantly speeds up the code and reduces memory footprint. 

If splinetables are not available (or user so chooses) scipy.gridinterpolator is used on the fly.

Time to generate 100 trials each simulating 10y of IC data (using 2 cores,  i5 8350u):

photospline on the fly (OLD):
[Creating analysis.                                ] 1.1e+03 sec/iter (1)
[Running trials.                                   ]  63.967 sec/iter (1)

photospline from disk (NEW)
[Creating analysis.                                ]  11.788 sec/iter (1)
[Running trials.                                   ]  55.713 sec/iter (1)

gridinterpolator on the fly (if photospline is not available)
[Creating analysis.                                ]  19.439 sec/iter (1)
[Running trials.                                   ] 153.576 sec/iter (1)

Maximum memory consumption:
photospline on the fly (OLD):    ~16GB
photospline from disk (NEW):   ~1.4 GB
gridinterpolator on the fly (if photospline is not available): ~2.1GB

![photospline_on_the_fly](https://user-images.githubusercontent.com/5701845/77163603-b878ce00-6aae-11ea-92a8-2e630fa83bd3.png)
![gridinterpolator_on_the_fly](https://user-images.githubusercontent.com/5701845/77163604-b9116480-6aae-11ea-86d3-7ada47dc901e.png)
![photospline_from_disk](https://user-images.githubusercontent.com/5701845/77163606-b9116480-6aae-11ea-8716-40fe77cf031a.png)


