### PR TITLE
Fix change_source method behavior. Closes #68

### DIFF
--- a/skyllh/core/analysis.py
+++ b/skyllh/core/analysis.py
@@ -1224,15 +1224,18 @@ class TimeIntegratedMultiDatasetSingleSourceAnalysis(Analysis):
         self._llhratio.change_source_hypo_group_manager(self._src_hypo_group_manager)
 
         # Change the source hypo group manager of the background generator
-        # instance.
-        if(self._bkg_generator is not None):
-            self._bkg_generator.change_source_hypo_group_manager(
-                self._src_hypo_group_manager)
+        # instance. Initialize the background generator if it does not exist.
+        if(self._bkg_generator is None):
+            self.construct_background_generator()
+        self._bkg_generator.change_source_hypo_group_manager(
+            self._src_hypo_group_manager)
 
         # Change the source hypo group manager of the signal generator instance.
-        if(self._sig_generator is not None):
-            self._sig_generator.change_source_hypo_group_manager(
-                self._src_hypo_group_manager)
+        # Initialize the signal generator if it does not exist.
+        if(self._sig_generator is None):
+            self.construct_signal_generator()
+        self._sig_generator.change_source_hypo_group_manager(
+            self._src_hypo_group_manager)
 
     def initialize_trial(self, events_list, n_events_list=None, tl=None):
         """This method initializes the multi-dataset log-likelihood ratio


### PR DESCRIPTION
Initializing a background or signal generator before executing `change_source_hypo_group_manager` method makes sure that the following trial generation uses an up to date source.