### PR TITLE
yaml should be optional

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ scipy
 sphinx
 sphinx_rtd_theme
 nbsphinx
-pyyaml

--- a/skyllh/core/config.py
+++ b/skyllh/core/config.py
@@ -8,7 +8,13 @@ from astropy import units  # type: ignore
 import os.path
 import sys
 from typing import Any, Dict, Iterator, KeysView, ItemsView, ValuesView
-import yaml
+
+# Try to load the yaml package.
+YAML_LOADED = True
+try:
+    import yaml
+except ImportError:
+    YAML_LOADED = False
 
 from skyllh.core.py import issequenceof
 
@@ -100,9 +106,12 @@ class CFGClass(dict):
             yaml_file: str
                 Path to yaml file.
         """
-
-        yaml_config = yaml.load(open(yaml_file), Loader=yaml.SafeLoader)
-        self.update(yaml_config)
+        if(YAML_LOADED):
+            yaml_config = yaml.load(open(yaml_file), Loader=yaml.SafeLoader)
+            self.update(yaml_config)
+        else:
+            raise ImportError(f'Could not import yaml package. Thus can not
+                               import config from yaml file {yaml_file}')
 
     def from_dict(self, user_dict: Dict[Any, Any]) -> None:
         """

--- a/skyllh/core/config.py
+++ b/skyllh/core/config.py
@@ -110,8 +110,8 @@ class CFGClass(dict):
             yaml_config = yaml.load(open(yaml_file), Loader=yaml.SafeLoader)
             self.update(yaml_config)
         else:
-            raise ImportError(f'Could not import yaml package. Thus can not
-                               import config from yaml file {yaml_file}')
+            raise ImportError(f'Could not import yaml package. Thus can not'
+                              f'import config from yaml file {yaml_file}')
 
     def from_dict(self, user_dict: Dict[Any, Any]) -> None:
         """


### PR DESCRIPTION
unfortunately yaml is not offered by icecube.cvmfs ..

not having a hard dependency helps with grid computing (since we avoid having to ship our own dependencies).