### PR TITLE
Monte Carlo injections fix

### DIFF
--- a/skyllh/core/background_generation.py
+++ b/skyllh/core/background_generation.py
@@ -431,12 +431,6 @@ class MCDataSamplingBkgGenMethod(BackgroundGenerationMethod):
 
         data_mc_pre_selected = self._cache_mc_pre_selected
 
-        # Scramble the pre-selected MC events if requested.
-        if(self._data_scrambler is not None):
-            with TaskTimer(tl, 'Scramble MC background data.'):
-                data_mc_pre_selected = self._data_scrambler.scramble_data(
-                    rss, data_mc_pre_selected, copy=False)
-
         # Select the significant events from the pre-selection.
         if(self__event_selection_method is None):
             data_mc_selected = data_mc_pre_selected
@@ -488,6 +482,12 @@ class MCDataSamplingBkgGenMethod(BackgroundGenerationMethod):
                 replace=(not self._unique_events))
         with TaskTimer(tl, 'Select MC background events from indices.'):
             bkg_events = data_mc_selected[bkg_event_indices]
+
+        # Scramble the drawn MC events if requested.
+        if(self._data_scrambler is not None):
+            with TaskTimer(tl, 'Scramble MC background data.'):
+                bkg_events = self._data_scrambler.scramble_data(
+                    rss, bkg_events, copy=False)
 
         # Remove MC specific data fields from the background events record
         # array. So the result contains only experimental data fields. The list

--- a/skyllh/core/background_generation.py
+++ b/skyllh/core/background_generation.py
@@ -278,8 +278,8 @@ class MCDataSamplingBkgGenMethod(BackgroundGenerationMethod):
 
     def change_source_hypo_group_manager(self, src_hypo_group_manager):
         """Changes the SourceHypoGroupManager instance of the
-        pre-event-selection and event-selection method. Also it invalides the
-        data cache of this background generation method.
+        pre-event-selection method. Also it invalides the data cache of this
+        background generation method.
 
         Parameters
         ----------
@@ -398,7 +398,6 @@ class MCDataSamplingBkgGenMethod(BackgroundGenerationMethod):
         # Apply only event pre-selection before choosing events.
         data_mc_selected = self._cache_mc_pre_selected
 
-        # Determine if there is an event selection at all.
         # Calculate the mean number of background events for the pre-selected
         # MC events.
         if(self__pre_event_selection_method is None):


### PR DESCRIPTION
1. Applies data scrambling after `rss.random.choice` function, which gets rid of duplicated pseudo events (due to not enough MC statistics for former order), and changes bkg TS distribution to fairly match the data scrambles TS distribution.

2. Removes event_selection_argument, because likelihood evaluation has its own optimization box.