### PR TITLE
Deploy documentation to gh-pages

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,0 +1,53 @@
+# This workflow builds sphinx documentation and deploys static html files to the gh-pages branch.
+# Based on https://github.com/marketplace/actions/github-pages-action#%EF%B8%8F-static-site-generators-with-python
+
+name: Build and deploy documentation
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.8'
+
+      - name: Upgrade pip
+        run: |
+          # install pip=>20.1 to use "pip cache dir"
+          python3 -m pip install --upgrade pip
+
+      - name: Get pip cache dir
+        id: pip-cache
+        run: echo "::set-output name=dir::$(pip cache dir)"
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.pip-cache.outputs.dir }}
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: python3 -m pip install -r ./doc/sphinx/requirements.txt
+        
+      - name: Install pandoc
+        run: sudo apt-get -y install pandoc
+
+      - name: Build documentation
+        run: |
+          cd ./doc/sphinx
+          make html          
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./doc/sphinx/_build/html

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -12,15 +12,18 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.insert(0, os.path.abspath('../../'))
 
 # -- Project information -----------------------------------------------------
 
+from datetime import date
+
+year = date.today().year
+
 project = u'SkyLLH'
-copyright = u'2019, The IceCube Collaboration, T. Kontrimas, M. Wolf'
+copyright = u'%s, The IceCube Collaboration, T. Kontrimas, M. Wolf' % year
 author = u'The IceCube Collaboration'
 
 # The short X.Y version

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,0 +1,5 @@
+ -r ../../requirements.txt
+sphinx
+sphinx_rtd_theme
+nbsphinx
+ipython

--- a/doc/sphinx/requirements.txt
+++ b/doc/sphinx/requirements.txt
@@ -1,4 +1,4 @@
- -r ../../requirements.txt
+-r ../../requirements.txt
 sphinx
 sphinx_rtd_theme
 nbsphinx

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,4 @@ astropy
 numpy
 scipy
 iminuit
-sphinx
-sphinx_rtd_theme
-nbsphinx
 matplotlib


### PR DESCRIPTION
Use github actions to automatically build sphinx documentation on push to master branch and deploy it to the gh-pages branch.